### PR TITLE
疑似bug一枚

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -1425,6 +1425,8 @@ get information of the given path (dir / file) at Baidu Yun.
 
 	def __upload_dir(self, localpath, remotepath, ondup = 'overwrite'):
 		self.pd("Uploading directory '{}' to '{}'".format(localpath, remotepath))
+		self.__current_file = localpath
+		self.__current_file_size = getfilesize(localpath)		
 		os.path.walk(localpath, self.__walk_upload, (localpath, remotepath, ondup))
 
 	def __upload_file(self, localpath, remotepath, ondup = 'overwrite'):


### PR DESCRIPTION
当 同步当前目录成功后， 紧接着立即再同步一次，报错：

Traceback (most recent call last):
  File "/root/bypy.py", line 2503, in <module>
    main()
  File "/root/bypy.py", line 2463, in main
    result = getattr(by, args.command[0])(*uargs)
  File "/root/bypy.py", line 1493, in upload
    return self.__upload_dir(lpath, rpath, ondup)
  File "/root/bypy.py", line 1428, in __upload_dir
    os.path.walk(localpath, self.__walk_upload, (localpath, remotepath, ondup))
  File "/root/GreenOpenERP-8.0-latest-linux-x64/python/bin/../../python/lib/python2.7/posixpath.py", line 238, in walk
    func(arg, top, names)
  File "/root/bypy.py", line 1417, in __walk_upload
    if subresult == ENoError and self.__verify_current_file(self.__remote_json, False):
  File "/root/bypy.py", line 1121, in __verify_current_file
    self.pd("Local file size : {}".format(self.__current_file_size))
AttributeError: 'ByPy' object has no attribute '_ByPy__current_file_size'
