### PR TITLE
修改下载续传速度计算，修改combine功能的Exception，修改进度显示精度等

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -314,7 +314,7 @@ def pprgrc(finish, total, start_time = None, existing = 0,
 				' (' + speed + ', ' + \
 				human_time(elapsed) + ' gone)'
 	msg = '\r' + prefix + '[' + segth * '=' + (seg - segth) * '_' + ']' + \
-		" {}% ({}/{})".format(percent, si_size(finish, 0), si_size(total, 0)) + \
+		" {}% ({}/{})".format(percent, si_size(finish), si_size(total)) + \
 		' ' + eta + suffix
 	sys.stderr.write(msg + ' ') # space is used as a clearer
 	sys.stderr.flush()


### PR DESCRIPTION
1.  修改了下载续传时速度计算错误  
   原来下载每一块时existing都将被更新为offset，导致finishf == 1048576.0，平均速度计算有误.
2.  修改combine后verify时size未定义  
   改为在未指定验证文件时直接不检查，指定了就计算出self.__current_file_size.
3.  修改了进度显示的精度  
   从(1.499G -> 1.0G)直接变为(1.500G -> 2.0G)不太适应，改成默认的三位小数了.
4.  文件大小不匹配时不再计算md5

我初学python，尚未仔细研读您的代码，如有不当之处，还请指正.
