### PR TITLE
standard install path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(
 	author_email='houtianze@gmail.com',
 	url='https://github.com/houtianze/bypy',
 	packages=find_packages(),
-	scripts=["bypy.py"],
+	scripts=["bypy.py","bypygui.pyw"],
 	)
 
 # vim: set fileencoding=utf-8


### PR DESCRIPTION
since it's application rather than python modules,
tests under Gentoo Linux

before, it will install to following path
 ~ # qlist -e bypy
/usr/lib64/python2.7/site-packages/bypy.pyo
/usr/lib64/python2.7/site-packages/bypy.py
/usr/lib64/python2.7/site-packages/bypy.pyc
/usr/lib64/python2.7/site-packages/bypy-1.0-py2.7.egg-info
/usr/share/doc/bypy-9999/README.md.bz2

after, it install 
# qlist -e bypy

/usr/lib64/python2.7/site-packages/bypy-1.0-py2.7.egg-info/SOURCES.txt
/usr/lib64/python2.7/site-packages/bypy-1.0-py2.7.egg-info/dependency_links.txt
/usr/lib64/python2.7/site-packages/bypy-1.0-py2.7.egg-info/top_level.txt
/usr/lib64/python2.7/site-packages/bypy-1.0-py2.7.egg-info/PKG-INFO
/usr/lib/python-exec/python2.7/bypygui.pyw
/usr/lib/python-exec/python2.7/bypy.py
/usr/bin/bypygui.pyw
/usr/bin/bypy.py
/usr/share/doc/bypy-9999/README.md.bz2
