### PR TITLE
Fixed InsecureRequestWarning

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -1036,10 +1036,10 @@ class ByPy(object):
 
 			if method.upper() == 'GET':
 				r = requests.get(url,
-					params = parsnew, timeout = self.__timeout, verify = False, **kwargs)
+					params = parsnew, timeout = self.__timeout, verify = True, **kwargs)
 			elif method.upper() == 'POST':
 				r = requests.post(url,
-					params = parsnew, timeout = self.__timeout, verify = False, **kwargs)
+					params = parsnew, timeout = self.__timeout, verify = True, **kwargs)
 
 			# BUGFIX: DON'T do this, if we are downloading a big file, the program sticks and dies
 			#self.pd("Request Headers: {}".format(


### PR DESCRIPTION
236定义的http貌似没有用到

参照[requests doc](http://docs.python-requests.org/en/latest/user/advanced/#ssl-cert-verification)
我觉着这么改一下就好了，至少我这是没有
InsecureRequestWarning了
