### PR TITLE
修复 -d 模式下的路径显示

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -817,7 +817,7 @@ class PathDictTree(dict):
 	def __str(self, prefix):
 		result = ''
 		for k, v in self.iteritems():
-			result += "{} - {}{} - size: {} - md5: {} \n".format(
+			result += "{} - {}/{} - size: {} - md5: {} \n".format(
 				v.type, prefix, k,
 				v.extra['size'] if 'size' in v.extra else '',
 				binascii.hexlify(v.extra['md5']) if 'md5' in v.extra else '')


### PR DESCRIPTION
Before this fix:

    F - /performance_schemausers.frm - size: 579 - md5: d87d5b8edfec6a92f540477a6b0938dd


After:

    F - /performance_schema/users.frm - size: 579 - md5: d87d5b8edfec6a92f540477a6b0938dd