### PR TITLE
增加错误代码 31081

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -1073,6 +1073,10 @@ class ByPy(object):
 				elif ec == IEMD5NotFound: # and sc == 404:
 					self.pd("MD5 not found, rapidupload failed")
 					result = ec
+				# superfile create failed
+				elif ec == 31081: # and sc == 404:
+					self.pd("blocks MD5 insufficient, rapidupload failed")
+					result = ec
 				# errors that make retrying meaningless
 				elif (
 					ec == 31061 or # sc == 400 file already exists


### PR DESCRIPTION
提交的分片 md5 不足以成功合并时，不要重试 5 次。

需要注意，[官方文档](http://developer.baidu.com/wiki/index.php?title=docs/pcs/rest/file_data_apis_error) 标注此错误对应的 http 状态码为 ``503``，但这种情况下返回的是 ``404``。

官方文档还列出了 ``31082``、``31083``，我目前没有遇到（影响到使用），暂且不添加。作者可酌情处理。

    HTTP/1.1 404 Not Found
    Content-Type: text/html
    
    {"error_code":31081,"error_msg":"superfile create failed","request_id":1435797171}