### PR TITLE
尝试用 sys.stdout.encoding 的值

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -80,9 +80,15 @@ if not SystemEncoding:
 import codecs
 # no idea who is the asshole that screws the sys.stdout.encoding
 # the locale is 'UTF-8', sys.stdin.encoding is 'UTF-8',
-# BUT, sys.stdout.encoding is 'None' ...
+# BUT, sys.stdout.encoding is None ...
 if not (sys.stdout.encoding and sys.stdout.encoding.lower() == 'utf-8'):
-	sys.stdout = codecs.getwriter("utf-8")(sys.stdout)
+	encoding_to_use = sys.stdout.encoding
+	try:
+		codecs.lookup(encoding_to_use)
+		u'汉字'.encode(encoding_to_use)
+	except: # (LookupError, TypeError, UnicodeEncodeError):
+		encoding_to_use = 'utf-8'
+	sys.stdout = codecs.getwriter(encoding_to_use)(sys.stdout)
 import signal
 import time
 import shutil


### PR DESCRIPTION
以 Windows 为例，`sys.stdout.encoding` 在管道模式下为 `None`，而在常规模式下为当前控制台编码（`cp936`、`cp65001` 等）。

原来的判断语句同时匹配了这两种情况，都以 `utf-8` 编码输出，导致在 `cp936` （简体 Windows 的默认编码）的控制台下看到的消息乱码。
所幸只是输出消息乱码，程序内部处理完全没有问题。

第二句 `u'汉字'.encode(encoding_to_use)` 是为了适配部分奇葩的 Linux 环境，默认编码为 `ANSI_X3.4-1968`…… `1968`...