### PR TITLE
stderr 的字符编码

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -92,6 +92,7 @@ if not (sys.stdout.encoding and sys.stdout.encoding.lower() == 'utf-8'):
 	except: # (LookupError, TypeError, UnicodeEncodeError):
 		encoding_to_use = 'utf-8'
 	sys.stdout = codecs.getwriter(encoding_to_use)(sys.stdout)
+	sys.stderr = codecs.getwriter(encoding_to_use)(sys.stderr)
 import signal
 import time
 import shutil
@@ -3098,6 +3099,7 @@ right after the '# PCS configuration constants' comment.
 		pr("App root path at Baidu Yun '{}'".format(AppPcsPath))
 		pr("sys.stdin.encoding = {}".format(sys.stdin.encoding))
 		pr("sys.stdout.encoding = {}".format(sys.stdout.encoding))
+		pr("sys.stderr.encoding = {}".format(sys.stderr.encoding))
 
 		if args.verbose > 0:
 			pr("Verbose level = {}".format(args.verbose))


### PR DESCRIPTION
之前的 #122 忘记考虑 stderr 的编码了。

这个 patch 假定用户的 stderr 和 stdout 编码一致，省去对 `sys.stderr.encoding` 的判断。
但愿不要有超出这个假定的用例...