### PR TITLE
处理过低版本的 sys.version_info

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -53,7 +53,7 @@ from __future__ import unicode_literals
 EIncorrectPythonVersion = 1
 import sys
 vi = sys.version_info
-if vi.major != 2 or vi.minor < 7:
+if not hasattr(sys.version_info, 'major') or vi.major != 2 or vi.minor < 7:
 	print("Error: Incorrect Python version. " + \
 		"You need 2.7 or above (but not 3)")
 	sys.exit(EIncorrectPythonVersion)


### PR DESCRIPTION
Python 2.7.6：
<pre>>>> sys.version_info
sys.version_info(major=2, minor=7, micro=6, releaselevel='final', serial=0)</pre>

Python 2.6.6：
<pre>>>> sys.version_info
(2, 6, 6, 'final', 0)</pre>

<pre>Traceback (most recent call last):
  File "/tmp/bypy/bypy.py", line 56, in &lt;module>
    if vi.major != 2 or vi.minor &lt; 7:
AttributeError: 'tuple' object has no attribute 'major'</pre>


修改后：
`Error: Incorrect Python version. You need 2.7 or above (but not 3)`