### PR TITLE
远程文件大小为 0 时的两个 bug

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -343,8 +343,12 @@ ask = askc
 def pprgrc(finish, total, start_time = None, existing = 0,
 		prefix = '', suffix = '', seg = 20):
 	# we don't want this goes to the log, so we use stderr
-	segth = seg * finish // total
-	percent = 100 * finish // total
+	if total > 0:
+		segth = seg * finish // total
+		percent = 100 * finish // total
+	else:
+		segth = seg
+		percent = 100
 	eta = ''
 	now = time.time()
 	if start_time is not None and percent > 5 and finish > 0:
@@ -2201,8 +2205,10 @@ try to create a file at PCS by combining slices, having MD5s specified
 			if nextoffset < rsize:
 				headers = { "Range" : "bytes={}-{}".format(
 					offset, nextoffset - 1) }
-			else:
+			elif offset > 0:
 				headers = { "Range" : "bytes={}-".format(offset) }
+			else:
+				headers = {}
 
 			subresult = self.__get(DPcsUrl + 'file', pars,
 				self.__downchunks_act, (rfile, offset, rsize, start_time), headers = headers)


### PR DESCRIPTION
`__downchunks()` 中：
远程文件长度为 0 时，第一次下载请求时的“`Range: bytes=0-`”会导致百度报参数错误：
`{"error_code":31023,"error_msg":"param error","request_id":2555305802}`
（暂时没调查是不是百度不符合规范）

同时修复 `pprgrc()` 在传入 `total` 为 0 时的报错：
<pre>Traceback (most recent call last):
  File "/root/bypy/bypy.py", line 1249, in __request_work
    result = act(r, actargs)
  File "/root/bypy/bypy.py", line 2351, in __downchunks_act
    pprgr(pos, rsize, start_time, existing = self.__existing_size)
  File "/root/bypy/bypy.py", line 348, in pprgrc
    segth = seg * finish // total
ZeroDivisionError: integer division or modulo by zero</pre>