### PR TITLE
下载异常时不显示响应报文内容

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -1206,8 +1206,9 @@ class ByPy(object):
 			perr("Website parameters: {}".format(pars))
 			if r:
 				perr("HTTP Status Code: {}".format(r.status_code))
-				self.__print_error_json(r)
-				perr("Website returned: {}".format(rb(r.text)))
+				if (r.status_code != 200 and r.status_code != 206) or (not (pars.has_key('method') and pars['method'] == 'download') and url.find('method=download') == -1 and url.find('baidupcs.com/file/') == -1):
+					self.__print_error_json(r)
+					perr("Website returned: {}".format(rb(r.text)))
 
 	# always append / replace the 'access_token' parameter in the https request
 	def __request_work(self, url, pars, act, method, actargs = None, addtoken = True, dumpex = True, **kwargs):


### PR DESCRIPTION
替代 #81 。

目前的判断条件：状态码为 200、206 且 method=download

<pre>&lt;E> [18:41:41] Error accessing 'https://d.pcs.baidu.com/rest/2.0/pcs/file'
&lt;E> [18:41:41] Exception:
[Errno 13] Permission denied: u'beingused'
Traceback (most recent call last):
  File "C:\data\bypy\bypy.py", line 1252, in __request_work
    result = act(r, actargs)
  File "C:\data\bypy\bypy.py", line 2181, in __downchunks_act
    with open(self.__current_file, 'r+b' if offset > 0 else 'wb') as f:
IOError: [Errno 13] Permission denied: u'beingused'

&lt;E> [18:41:41] Function: __downchunks_act
&lt;E> [18:41:41] Website parameters: {u'path': u'/apps/bypy/beingused', u'method':
 u'download'}
&lt;E> [18:41:41] HTTP Status Code: 200
&lt;E> [18:41:41] Fatal Exception, no way to continue.
Quitting...
</pre>