### PR TITLE
syncup() 覆盖时不删除文件，而是创建新版本

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -2886,7 +2886,12 @@ if not specified, it defaults to the root directory
 			if self.shalloverwrite("Do you want to overwrite '{}' at Baidu Yun? [y/N]".format(p)):
 				# this path is before get_pcs_path() since delete() expects so.
 				#result = self.delete(rpartialdir + '/' + p)
-				result = self.__delete(rcpath)
+				#result = self.__delete(rcpath)
+				self.pd("diff type: {}".format(t))
+				self.__isrev = True
+				if t != 'F':
+					result = self.move(remotedir + '/' + p, remotedir + '/' + p + '.moved_by_bypy.' + time.strftime("%Y%m%d%H%M%S"))
+					self.__isrev = False
 				if t == 'F' or t == 'FD':
 					subresult = self.__upload_file(lcpath, rcpath)
 					if subresult != ENoError:
@@ -2904,6 +2909,8 @@ if not specified, it defaults to the root directory
 			#lcpath = os.path.join(localdir, p) # local complete path
 			lcpath = joinpath(localdir, p) # local complete path
 			rcpath = rpath + '/' + p # remote complete path
+			self.pd("local type: {}".format(t))
+			self.__isrev = False
 			if t == 'F':
 				subresult = self.__upload_file(lcpath, rcpath)
 				if subresult != ENoError:


### PR DESCRIPTION
#131 的后续。
因为自己一直在用，目前看来没有什么问题（除了某些大文件恢复不出来）。

`diff` 类型：
`DF/FD` => 远程文件/文件夹改名（建议提供选项，允许修改行为）
`FF` => 创建版本

这样回收站比较干净。
建议允许用户选择原来的直接删除方式，简单粗暴但非常有效。

---

md5 方面：以前的文件经过覆盖能得到正确的 md5 值，但最近几个月没有出现严重的 md5 错乱现象，不敢说异常期间这招能管用。