### PR TITLE
__dump_exception() 中的 r 有时会求得 False

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -1228,8 +1228,8 @@ class ByPy(object):
 				pr(tb)
 			perr("Function: {}".format(act.__name__))
 			perr("Website parameters: {}".format(pars))
-			if r:
-				perr("HTTP Status Code: {}".format(r.status_code))
+			if hasattr(r, 'status_code'):
+				perr("HTTP Response Status Code: {}".format(r.status_code))
 				if (r.status_code != 200 and r.status_code != 206) or (not (pars.has_key('method') and pars['method'] == 'download') and url.find('method=download') == -1 and url.find('baidupcs.com/file/') == -1):
 					self.__print_error_json(r)
 					perr("Website returned: {}".format(rb(r.text)))

--- a/bypy.py
+++ b/bypy.py
@@ -91,6 +91,7 @@ if not (sys.stdout.encoding and sys.stdout.encoding.lower() == 'utf-8'):
 		u'汉字'.encode(encoding_to_use)
 	except: # (LookupError, TypeError, UnicodeEncodeError):
 		encoding_to_use = 'utf-8'
+		sys.exc_clear()
 	sys.stdout = codecs.getwriter(encoding_to_use)(sys.stdout)
 	sys.stderr = codecs.getwriter(encoding_to_use)(sys.stderr)
 import signal


### PR DESCRIPTION
重现：`bypy.py mkdir "C:\\Windows" -v -d`
（通过 `"error_code": 31062` 调用 `__dump_exception()`）
不确定这个情况是普遍还是针对特定版本。

本 patch 有三处改动：
- 通过判断 `r` 是否有 `status_code` 属性来决定是否打印响应内容
 - 证明：状态码为 400 时，打印 `not not r` 可以得到 `False`
- 修改一处响应提示文字，以便与另一处一样的提示区分开，方便调试（很自私的决定）
- 将测试编码时触发的异常清除（否则非异常时主动调用 `__dump_exception()` 会打印出来）

修改前：
````
<D> POST https://pcs.baidu.com/rest/2.0/pcs/file
<D> actargs: None
<D> Params: {u'path': u'/apps/bypy/C:\\\\Windows', u'method': u'mkdir'}
<D> HTTP Status Code: 400
<E> [20:30:17] Error accessing 'https://pcs.baidu.com/rest/2.0/pcs/file'
Traceback (most recent call last):
  File "C:\data\bypy\bypy.py", line 90, in <module>
    codecs.lookup(encoding_to_use)
LookupError: unknown encoding: cp65001

<E> [20:30:17] Function: __mkdir_act
<E> [20:30:17] Website parameters: {u'path': u'/apps/bypy/C:\\\\Windows', u'meth
od': u'mkdir'}
````

修改后：
````
<D> POST https://pcs.baidu.com/rest/2.0/pcs/file
<D> actargs: None
<D> Params: {u'path': u'/apps/bypy/C:\\\\Windows', u'method': u'mkdir'}
<D> HTTP Status Code: 400
<E> [20:25:43] Error accessing 'https://pcs.baidu.com/rest/2.0/pcs/file'
None

<E> [20:25:43] Function: __mkdir_act
<E> [20:25:43] Website parameters: {u'path': u'/apps/bypy/C:\\\\Windows', u'meth
od': u'mkdir'}
<E> [20:25:43] Website response: False
<E> [20:25:43] HTTP Response Status Code: 400
<E> [20:25:43] Error code: 31062
Error Description: file name is invalid
<E> [20:25:43] Website returned: {"error_code":31062,"error_msg":"file name is i
nvalid","request_id":3920565160}
````

---

遗留问题：状态码为 200，有可能是被重定向到 http://pan.baidu.com/error/core.html
不容易重现，所以一直没有处理。