### PR TITLE
处理违禁文件的跳转

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -1273,6 +1273,9 @@ class ByPy(object):
 				result = act(r, actargs)
 				if result == ENoError:
 					self.pd("Request all goes fine")
+			elif sc == 404 and r.url.find('http://bcscdn.baidu.com/bcs-cdn/wenxintishi') == 0: # = "error_code":31390,"error_msg":"Illegal File"
+				self.pd("File is blacklisted ('wenxintishi'). Skipping.")
+				result = EFileNotFound
 			else:
 				ec = 0
 				try:


### PR DESCRIPTION
下载违禁文件时：
`Location: http://bcscdn.baidu.com/bcs-cdn/wenxintishi-任意整数.avi?response-content-disposition=attachment;%20filename=%e6%b8%a9%e9%a6%a8%e6%8f%90%e7%a4%ba.avi`

得到的响应虽然是标准的 JSON，但没有 `error_code`。需要作额外判断。


修改前：
```
<E> [18:13:02] Error accessing 'https://d.pcs.baidu.com/rest/2.0/pcs/file'
<E> [18:13:02] Exception:
u'error_code'
Traceback (most recent call last):
  File "/root/bypy/bypy.py", line 1297, in __request_work
    ec = j['error_code']
KeyError: u'error_code'

<E> [18:13:02] Function: __downchunks_act
<E> [18:13:02] Website parameters: {u'path': u'/apps/bypy/\u4e09\u56fd\u6f14\u4e49.E63.1994.DVDRip.x264.AC3-CMCT~2E1776FEF72190D8BF45662363114CF8.mkv', u'method': u'download'}
<E> [18:13:02] Website response: False
<E> [18:13:02] HTTP Response Status Code: 404
<E> [18:13:02] Website returned: {"Error":{"code":"2","Message":"object not exists","LogId":"772218221"}}
<E> [18:13:02] Fatal Exception, no way to continue.
Quitting...

<E> [18:13:02] If the error is reproducible, run the program with `-dv` arguments again to get more info.

```