### PR TITLE
修正 human_num(0)

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -528,7 +528,7 @@ def interpret_size(si):
 def human_num(num, precision = 0, filler = ''):
 	# https://stackoverflow.com/questions/15263597/python-convert-floating-point-number-to-certain-precision-then-copy-to-string/15263885#15263885
 	numfmt = '{{:.{}f}}'.format(precision)
-	exp = math.log(num, OneK)
+	exp = math.log(num, OneK) if num > 0 else 0
 	expint = int(math.floor(exp))
 	maxsize = len(SIPrefixNames) - 1
 	if expint > maxsize:


### PR DESCRIPTION
类似于 #143 。
文件长度为 0 时：
```
<D> GET https://d.pcs.baidu.com/rest/2.0/pcs/file
<D> actargs: (u'/apps/bypy/\u60a8\u4e0b\u8f7d\u7684\u5185\u5bb9\u4e2d\u5305\u542b\u8fdd\u89c4\u4fe1\u606f\uff01.txt', 0, 0, 1434092144.587769)
<D> Params: {u'path': u'/apps/bypy/\u60a8\u4e0b\u8f7d\u7684\u5185\u5bb9\u4e2d\u5305\u542b\u8fdd\u89c4\u4fe1\u606f\uff01.txt', u'method': u'download'}
<D> HTTP Status Code: 200
<D> Request OK, processing action
<E> [14:55:44] Error accessing 'https://d.pcs.baidu.com/rest/2.0/pcs/file'
<E> [14:55:44] Exception:
math domain error
Traceback (most recent call last):
  File "/root/bypy/bypy.py", line 1282, in __request_work
    result = act(r, actargs)
  File "/root/bypy/bypy.py", line 2560, in __downchunks_act
    pprgr(pos, rsize, start_time, existing = self.__existing_size)
  File "/root/bypy/bypy.py", line 389, in pprgrc
    ' ' + eta + suffix
  File "/root/bypy/bypy.py", line 547, in human_size
    return human_num(num, precision) + 'B'
  File "/root/bypy/bypy.py", line 531, in human_num
    exp = math.log(num, OneK)
ValueError: math domain error
```
