### PR TITLE
下载文件时遇到 gzip 编码的问题

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -2399,6 +2399,8 @@ try to create a file at PCS by combining slices, having MD5s specified
 					offset, nextoffset - 1) }
 			elif offset > 0:
 				headers = { "Range" : "bytes={}-".format(offset) }
+			elif rsize >= 1: # offset == 0
+				headers = { "Range" : "bytes=0-".format(rsize - 1) }
 			else:
 				headers = {}
 


### PR DESCRIPTION
最近遇到一些 `Server: POMS/CloudUI 1.0`，域名为 `*.poms.baidupcs.com`，不同于往常的 `Server: BaiduBS`。

它们会在请求头不存在 `Range:` 时返回 chunked + gzip 编码的响应（至于有没有尊重 `Accept-Encoding:`，我没有做深入测试），导致下载超时。
超时可能是 urllib3 的问题，也可能是 requests 配置的问题，我没有仔细研究。

可以重现的一个文件：http://pan.baidu.com/s/1bn0Ly8n

目前的改动主要是出于 1b58b5011a 的罪恶感，但并不是最好的方案，请谨慎采用...

---

`bypy -ddd` 看到的请求：
```
INFO:urllib3.connectionpool:Starting new HTTPS connection (1): d.pcs.baidu.com
send: 'GET /rest/2.0/pcs/file?...&path=%2Fapps%2Fbypy%2Fmd5.d2.20150610.txt&method=download HTTP/1.1\r\nHost: d.pcs.baidu.com\r\nAccept-Encoding: gzip, deflate, compress\r\nAccept: */*\r\n\r\n'
DEBUG:urllib3.connectionpool:Setting read timeout to 60.0
reply: 'HTTP/1.1 302 Found\r\n'
header: Access-Control-Allow-Origin: *
header: Access-Control-Allow-Methods: GET, PUT, POST, DELETE, OPTIONS, HEAD
header: x-pcs-request-id: MTAuNTguMTMzLjU0OjgwODA6MzYyNDE4NzA5MjoxMi9KdW4vMjAxNSAxNTozODowOCA=
header: Server: nginx/1.4.2
header: Date: Fri, 12 Jun 2015 07:38:08 GMT
header: Content-Type: application/octet-stream
header: x-poms-key: 14005e7ee2f79aaf4aa0437983bb766de0a2a9151d4e00000000132a
header: Location: http://nb.poms.baidupcs.com/file/5e7ee2f79aaf4aa0437983bb766de0a2?...
header: x-bs-client-ip: ...
header: Content-Length: 43
header: Connection: close
DEBUG:urllib3.connectionpool:"GET /rest/2.0/pcs/file?...&path=%2Fapps%2Fbypy%2Fmd5.d2.20150610.txt&method=download HTTP/1.1" 302 43
INFO:urllib3.connectionpool:Starting new HTTP connection (1): nb.poms.baidupcs.com
send: 'GET /file/5e7ee2f79aaf4aa0437983bb766de0a2?... HTTP/1.1\r\nHost: nb.poms.baidupcs.com\r\nAccept-Encoding: gzip, deflate, compress\r\nAccept: */*\r\n\r\n'
DEBUG:urllib3.connectionpool:Setting read timeout to 60.0
reply: 'HTTP/1.1 200 OK\r\n'
header: Date: Fri, 12 Jun 2015 07:38:09 GMT
header: Content-Type: text/plain
header: Transfer-Encoding: chunked
header: Connection: keep-alive
header: Vary: Accept-Encoding
header: Content-Disposition: attachment;filename="md5.d2.20150610.txt"
header: crc32: 2836733262
header: Cache-Control: max-age=259200
header: Last-Modified: Wed, 10 Jun 2015 09:08:40 GTM
header: x-pcs-request-id: MTAuOTguMzkuNDY6ODY2MDozNzcyMzQ3MzM3MDQ3MzE1MzU2OjIwMTUtMDYtMTIgMTU6Mzg6MDg=
header: Content-MD5: 5e7ee2f79aaf4aa0437983bb766de0a2
header: superfile: 0
header: Server: POMS/CloudUI 1.0
header: Content-Encoding: gzip
DEBUG:urllib3.connectionpool:"GET /file/5e7ee2f79aaf4aa0437983bb766de0a2?... HTTP/1.1" 200 None
<E> [15:39:09] Error accessing 'https://d.pcs.baidu.com/rest/2.0/pcs/file'
<E> [15:39:09] Exception:
timed out
Traceback (most recent call last):
  File "/root/bypy/bypy.py", line 1256, in __request_work
    params = parsnew, timeout = self.__timeout, verify = self.__checkssl, proxies = proxies, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 55, in get
    return request('get', url, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/api.py", line 44, in request
    return session.request(method=method, url=url, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 455, in request
    resp = self.send(prep, **send_kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 578, in send
    history = [resp for resp in gen] if allow_redirects else []
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 178, in resolve_redirects
    allow_redirects=False,
  File "/usr/lib/python2.7/dist-packages/requests/sessions.py", line 558, in send
    r = adapter.send(request, **kwargs)
  File "/usr/lib/python2.7/dist-packages/requests/adapters.py", line 394, in send
    r.content
  File "/usr/lib/python2.7/dist-packages/requests/models.py", line 679, in content
    self._content = bytes().join(self.iter_content(CONTENT_CHUNK_SIZE)) or bytes()
  File "/usr/lib/python2.7/dist-packages/requests/models.py", line 616, in generate
    decode_content=True):
  File "/usr/lib/python2.7/dist-packages/urllib3/response.py", line 225, in stream
    data = self.read(amt=amt, decode_content=decode_content)
  File "/usr/lib/python2.7/dist-packages/urllib3/response.py", line 174, in read
    data = self._fp.read(amt)
  File "/usr/lib/python2.7/httplib.py", line 543, in read
    return self._read_chunked(amt)
  File "/usr/lib/python2.7/httplib.py", line 585, in _read_chunked
    line = self.fp.readline(_MAXLINE + 1)
  File "/usr/lib/python2.7/socket.py", line 476, in readline
    data = self._sock.recv(self._rbufsize)
timeout: timed out

<E> [15:39:09] Function: __downchunks_act
<E> [15:39:09] Website parameters: {u'path': u'/apps/bypy/md5.d2.20150610.txt', u'method': u'download'}
<E> [15:39:09] Website response: False
<E> [15:39:09] Waiting 10 seconds before retrying...
<E> [15:39:19] Request Try #2 / 5
```

Wireshark 看到的 bypy 下载请求（服务器返回的内容是完整的）：
```
GET /file/5e7ee2f79aaf4aa0437983bb766de0a2?... HTTP/1.1
Host: qd.poms.baidupcs.com
Connection: keep-alive
Accept-Encoding: gzip, deflate
Accept: */*

HTTP/1.1 200 OK
Date: Fri, 12 Jun 2015 07:28:40 GMT
Content-Type: text/plain
Transfer-Encoding: chunked
Connection: keep-alive
Vary: Accept-Encoding
Content-Disposition: attachment;filename="md5.d2.20150610.txt"
crc32: 2836733262
Cache-Control: max-age=259200
Last-Modified: Wed, 10 Jun 2015 09:08:40 GTM
x-pcs-request-id: MTAuNTQuMjcuMjc6ODY2MDozNzcyMTk0ODM4MzA5ODAwNTU4OjIwMTUtMDYtMTIgMTU6Mjg6NDA=
Content-MD5: 5e7ee2f79aaf4aa0437983bb766de0a2
superfile: 0
Server: POMS/CloudUI 1.0
Content-Encoding: gzip

680
...........
```

百度云管家的请求（响应内容无压缩）：
```
GET /file/5e7ee2f79aaf4aa0437983bb766de0a2?... HTTP/1.1
Range: bytes=0-4905
Host: qd.poms.baidupcs.com
Accept: */*
Connection: Keep-Alive
User-Agent: netdisk;5.2.7.2;PC;PC-Windows;6.2.9200;WindowsBaiduYunGuanJia

HTTP/1.1 206 Partial Content
Date: Fri, 12 Jun 2015 07:12:16 GMT
Content-Type: text/plain
Connection: keep-alive
Content-Disposition: attachment;filename="md5.d2.20150610.txt"
crc32: 2836733262
Cache-Control: max-age=259200
ETag: 5e7ee2f79aaf4aa0437983bb766de0a2
Last-Modified: Wed, 10 Jun 2015 09:08:40 GTM
Content-Length: 4906
x-pcs-request-id: MTAuNTQuMjkuMjc6ODY2MDozNzcxOTMwNjI4OTUzODEzNjIzOjIwMTUtMDYtMTIgMTU6MTI6MTY=
Content-Range: bytes 0-4905/4906
Content-MD5: 5e7ee2f79aaf4aa0437983bb766de0a2
superfile: 0
Accept-Ranges: bytes
Server: POMS/CloudUI 1.0

d5e37ca019e43b7a82c4365b8661b027 ...
```