### PR TITLE
解决 {'error_code': 0, 'error_msg': 'no error'}

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -1261,6 +1261,14 @@ class ByPy(object):
 			#self.pd("Website returned: {}".format(rb(r.text)), 3)
 			if sc == requests.codes.ok or sc == 206: # 206 Partial Content
 				if sc == requests.codes.ok:
+					if not (hasattr(pars, 'method') and pars['method'] == 'download'):
+						try:
+							j = r.json()
+							if hasattr(j, 'error_code') and j['error_code'] == 0 and hasattr(j, 'error_msg') and j['error_msg'] == 'no error': # __walk_remote_dir_act() KeyError: u'list'
+								self.pd("Unexpected response: {}".format(j))
+								return ERequestFailed
+						except Exception:
+							sys.exc_clear()
 					self.pd("Request OK, processing action")
 				else:
 					self.pd("206 Partial Content")


### PR DESCRIPTION
目前只在遍历深层目录（`__walk_remote_dir_act()`）时遇到过，通常再次请求就能得到正确结果，因此这里返回 `ERequestFailed`。
