### PR TITLE
syncup() 遍历时跳过远程存在但本地不存在的文件（夹）

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -2591,7 +2591,7 @@ To stream a file, you can use the 'mkfifo' trick with omxplayer etc.:
 
 		return ENoError
 
-	def __walk_remote_dir(self, remotepath, proceed, args = None):
+	def __walk_remote_dir(self, remotepath, proceed, args = None, tweak_for_syncup = False):
 		pars = {
 			'method' : 'list',
 			'path' : remotepath,
@@ -2611,7 +2611,10 @@ To stream a file, you can use the 'mkfifo' trick with omxplayer etc.:
 					subresult, remotepath))
 				result = subresult # we continue
 			for dirj in dirjs:
-				subresult = self.__walk_remote_dir(dirj['path'], proceed, args)
+				if tweak_for_syncup and args != None and args.startswith('/apps') and self.__local_dir_contents.get(posixpath.relpath(dirj['path'], args)) == None:
+					self.pd("Skipping '{}'. No same-name local dir/file exists.".format(dirj['path']))
+					continue
+				subresult = self.__walk_remote_dir(dirj['path'], proceed, args, tweak_for_syncup)
 				if subresult != ENoError:
 					self.pd("Error: {} while sub-walking remote dirs'{}'".format(
 						subresult, dirjs))
@@ -2918,13 +2921,13 @@ restore a file from the recycle bin
 
 		return ENoError
 
-	def __gather_remote_dir(self, rdir):
+	def __gather_remote_dir(self, rdir, tweak_for_syncup = False):
 		self.__remote_dir_contents = PathDictTree()
-		self.__walk_remote_dir(rdir, self.__proceed_remote_gather, rdir)
+		self.__walk_remote_dir(rdir, self.__proceed_remote_gather, rdir, tweak_for_syncup)
 		self.pd("---- Remote Dir Contents ---")
 		self.pd(self.__remote_dir_contents)
 
-	def __compare(self, remotedir = None, localdir = None):
+	def __compare(self, remotedir = None, localdir = None, tweak_for_syncup = False):
 		if not localdir:
 			localdir = '.'
 
@@ -2932,7 +2935,7 @@ restore a file from the recycle bin
 		self.__gather_local_dir(localdir)
 		self.pv("Done")
 		self.pv("Gathering remote directory ...")
-		self.__gather_remote_dir(remotedir)
+		self.__gather_remote_dir(remotedir, tweak_for_syncup)
 		self.pv("Done")
 		self.pv("Comparing ...")
 		# list merge, where Python shines
@@ -3082,7 +3085,7 @@ if not specified, it defaults to the root directory
 		result = ENoError
 		rpath = get_pcs_path(remotedir)
 		#rpartialdir = remotedir.rstrip('/ ')
-		same, diff, local, remote = self.__compare(rpath, localdir)
+		same, diff, local, remote = self.__compare(rpath, localdir, True)
 		# clear the way
 		for d in diff:
 			t = d[0] # type


### PR DESCRIPTION
替代 #164 。针对 Windows 环境下路径分隔符的问题作了处理。

---
这个改动我测试得不仔细，请仔细考察后再合并...

本地文件 `a`，远程文件夹 `a`，则重命名远程文件夹（@238a6f7）。
本地不存在文件夹 `a`，远程存在文件夹 `a`，则遍历时跳过 `a`。