### PR TITLE
ignore the signal when a user logouts the terminal

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -3245,7 +3245,8 @@ def main(argv=None): # IGNORE:C0111
 		pass
 	else:
 		signal.signal(signal.SIGBUS, sighandler)
-		signal.signal(signal.SIGHUP, sighandler)
+		# ignore the signal when a user logouts the terminal
+		signal.signal(signal.SIGHUP, signal.SIG_IGN)
 		# https://stackoverflow.com/questions/108183/how-to-prevent-sigpipes-or-handle-them-properly
 		signal.signal(signal.SIGPIPE, signal.SIG_IGN)
 		signal.signal(signal.SIGQUIT, sighandler)


### PR DESCRIPTION
在用ssh连接远程主机注销的时候，忽略Hangup信号，保证后台运行的bypy.py程序不会退出。