### PR TITLE
Fix upload slice fail

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -2081,6 +2081,8 @@ get information of the given path (dir / file) at Baidu Yun.
 					else:
 						self.__slice_md5s = []
 						break
+				if ec != ENoError:
+					break
 				i += 1
 
 		if ec != ENoError:


### PR DESCRIPTION
When upload a big file, it will be sliced to several pieces. If any piece upload failed, this tool will not recognize the file is broken in BaiduYun, because the default behavior of this tool is do **NOT** verify the file when combine the pieces to the whole file.

Thereby, we should stop the upload progress when any piece is upload failed to ensure the file is upload correctly.