### PR TITLE
Basic Python 3 support for GUI

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -829,7 +829,10 @@ class cached(object):
 			if os.path.exists(cached.hashcachepath):
 				try:
 					with open(cached.hashcachepath, 'rb') as f:
-						cached.cache = pickle.load(f)
+						if sys.version_info[0] == 3:
+							cached.cache = pickle.load(f, encoding="bytes")
+						else:
+							cached.cache = pickle.load(f)
 					cached.cacheloaded = True
 					if cached.verbose:
 						pr("Hash Cache File loaded.")

--- a/bypygui.pyw
+++ b/bypygui.pyw
@@ -6,16 +6,25 @@
 # Licensed under the GPLv3
 # https://www.gnu.org/licenses/gpl-3.0.txt
 
+from __future__ import division
 import sys
 import threading
-import Tkinter as tk
-import tkFileDialog
 
 vi = sys.version_info
 if vi[0] == 2:
 	import ScrolledText as scrt
+	import Tkinter as tk
+	import tkFileDialog
+	import tkMessageBox
+	import ttk
+	def iteritems(d):
+		return d.iteritems()
 elif vi[0] == 3:
-	import scrolledtext as scrt
+	from tkinter import scrolledtext as scrt
+	import tkinter as tk
+	from tkinter import filedialog as tkFileDialog, messagebox as tkMessageBox, ttk
+	def iteritems(d):
+		return d.items()
 
 MyReadOnlyText = tk.Text
 MyLogText = scrt.ScrolledText
@@ -42,8 +51,6 @@ try:
 except:
 	# it's OK, we just ignore it
 	pass
-import tkMessageBox
-import ttk
 
 import bypy
 
@@ -66,8 +73,8 @@ def centerwindow(w):
 	w.update() # fucking bit me
 	sw, sh = w.winfo_screenwidth(), w.winfo_screenheight()
 	width, height = w.winfo_width(), w.winfo_height()
-	x = (sw - width) / 2
-	y = (sh - height) / 2
+	x = (sw - width) // 2
+	y = (sh - height) // 2
 	w.geometry('{}x{}+{}+{}'.format(width, height, x, y))
 
 def fgtag(text):
@@ -380,7 +387,7 @@ class BypyGui(tk.Frame):
 
 		#self.wLog.tag_add(fgtag(''))
 		#self.wLog.tag_add(bgtag(''))
-		for k, v in ColorMap.iteritems():
+		for k, v in iteritems(ColorMap):
 			ft = fgtag(v)
 			bt = bgtag(v)
 			#self.wLog.tag_add(ft)


### PR DESCRIPTION
I'm not sure what's the effect of ```encoding="bytes"``` in pickle.load, but it saves me from the following exception when starting GUI:

```
Loading Hash Cache File '/home/yen/.bypy/bypy.pickle'...
<E> [22:01:25] Fail to load the Hash Cache, no caching. Exception:
  File "./bypygui.pyw", line 489, in <module>
    main()
  File "./bypygui.pyw", line 485, in main
    ui = BypyGui(tkRoot)
  File "./bypygui.pyw", line 312, in __init__
    self.initbypy()
  File "./bypygui.pyw", line 401, in initbypy
    self.byp = bypy.ByPy(verbose = 1)
  File "/home/yen/tmp/bypy/bypy.py", line 1291, in __init__
    cached.loadcache()
  File "/home/yen/tmp/bypy/bypy.py", line 840, in loadcache
    perr("Fail to load the Hash Cache, no caching. Exception:\n{}".format(format_exc_str()))
  File "/home/yen/tmp/bypy/bypy.py", line 426, in format_exc_str
    return ''.join(format_exc(**kwargs))
  File "/home/yen/tmp/bypy/bypy.py", line 423, in format_exc
    return traceback.format_stack(**kwargs)
```