### PR TITLE
wrap json.dumps with unicode to ensure type

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -761,7 +761,7 @@ def joinpath(first, second, sep = os.sep):
 # http://houtianze.github.io/python/unicode/json/2016/01/03/another-python-unicode-fisaco-on-json.html
 def py2_jsondump(data, filename):
 	with io.open(filename, 'w', encoding = 'utf-8') as f:
-		f.write(json.dumps(data, ensure_ascii = False, sort_keys = True, indent = 2))
+		f.write(unicode(json.dumps(data, ensure_ascii = False, sort_keys = True, indent = 2)))
 
 def py3_jsondump(data, filename):
 	with io.open(filename, 'w', encoding = 'utf-8') as f:

--- a/bypy.py
+++ b/bypy.py
@@ -761,7 +761,7 @@ def joinpath(first, second, sep = os.sep):
 # http://houtianze.github.io/python/unicode/json/2016/01/03/another-python-unicode-fisaco-on-json.html
 def py2_jsondump(data, filename):
 	with io.open(filename, 'w', encoding = 'utf-8') as f:
-		f.write(json.dumps(data, f, ensure_ascii = False, sort_keys = True, indent = 2))
+		f.write(json.dumps(data, ensure_ascii = False, sort_keys = True, indent = 2))
 
 def py3_jsondump(data, filename):
 	with io.open(filename, 'w', encoding = 'utf-8') as f:


### PR DESCRIPTION
`json.dumps` does not guarantee return unicode, wrap it with `unicode()`

`json.dumps(data, ensure_ascii=False)`
According to python doc, "If ensure_ascii is False, then the return value will be a unicode instance.".
But, if `data` does not contain any unicode instance, it will return a str. which in bypy jsondump caused an error:
TypeError: must be unicode, not str

To reproduce the problem, try
```
def py2_jsondump(data, filename):
	with io.open(filename, 'w', encoding = 'utf-8') as f:
		f.write(json.dumps(data, f, ensure_ascii = False, sort_keys = True, indent = 2))

py2_jsondump({}, "test.json")
```