### PR TITLE
Fix `TypeError: b'xxxxxx' is not JSON serializable`

### DIFF
--- a/bypy.py
+++ b/bypy.py
@@ -847,13 +847,7 @@ class cached(object):
 					and info['mtime'] == getfilemtime_int(path) \
 					and self.f.__name__ in info \
 					and cached.usecache:
-					# NOTE: behavior change: hexlify & unhexlify
-					#result = info[self.f.__name__]
-					# TODO: HACK here
-					if self.f.__name__ == 'crc32': # it's a int (long), can't unhexlify
-						result = info[self.f.__name__]
-					else:
-						result = info[self.f.__name__]
+					result = info[self.f.__name__]
 					if cached.debug:
 						pdbg("Cache hit for file '{}',\n{}: {}\nsize: {}\nmtime: {}".format(
 							path, self.f.__name__,
@@ -881,13 +875,7 @@ class cached(object):
 		cached.dirty = True
 		info['size'] = getfilesize(path)
 		info['mtime'] = getfilemtime_int(path)
-		# NOTE: behavior change: hexlify & unhexlify
-		#info[self.f.__name__] = value
-		# TODO: HACK here
-		if self.f.__name__ == 'crc32': # it's a int (long), can't hexlify
-			info[self.f.__name__] = value
-		else:
-			info[self.f.__name__] = value
+		info[self.f.__name__] = value
 		if cached.debug:
 			situation = "Storing cache"
 			if cached.usecache:
@@ -2380,7 +2368,7 @@ get information of the given path (dir / file) at Baidu Yun.
 				for md in md5s:
 					cslice = f.read(slice)
 					cm = hashlib.md5(cslice)
-					if (binascii.hexlify(cm.hexdigest()) == md):
+					if (cm.hexdigest() == md):
 						self.pd("{} verified".format(md))
 						self.__slice_md5s.append(md)
 					else:

--- a/bypy.py
+++ b/bypy.py
@@ -851,7 +851,7 @@ class cached(object):
 					if cached.debug:
 						pdbg("Cache hit for file '{}',\n{}: {}\nsize: {}\nmtime: {}".format(
 							path, self.f.__name__,
-							result if isinstance(result, (int, long, float, complex)) else result,
+							result,
 							info['size'], info['mtime']))
 				else:
 					result = self.f(*args)
@@ -882,7 +882,7 @@ class cached(object):
 				situation = "Cache miss"
 			pdbg((situation + " for file '{}',\n{}: {}\nsize: {}\nmtime: {}").format(
 				path, self.f.__name__,
-				value if isinstance(value, (int, long, float, complex)) else value,
+				value,
 				info['size'], info['mtime']))
 
 		# periodically save to prevent loss in case of system crash
@@ -1259,7 +1259,7 @@ class ByPy(object):
 	def convertbincache(info, key):
 		if key in info:
 			binhash = info[key]
-			strhash = binhash
+			strhash = binascii.hexlify(binhash)
 			info[key] = strhash
 
 	# in Pickle, i saved the hash (MD5, CRC32) in binary format (bytes)


### PR DESCRIPTION
When I run upload/syncup in python3, it gives me something like

```
<E> [10:53:00] Failed to save Hash Cache.
Exception:
<class 'TypeError'> - b'52476ea8c296992547087e1f04239698' is not JSON serializable
Stack:
  File "./bypy.py", line 4418, in <module>
    main()
  File "./bypy.py", line 4415, in main
    onexit(result)
  File "./bypy.py", line 4191, in onexit
    cached.savecache()
  File "./bypy.py", line 1006, in savecache
    perr("Failed to save Hash Cache.\n{}".format(formatex(ex)))
  File "./bypy.py", line 485, in formatex
    type(ex), ex, ''.join(traceback.format_stack()))
```

Using hashlib.hexdigest instead of hashlib.digest can avoid this problem.

The reason is that in python2, hashlib.digest returns str, but in python3, hashlib.digest returns bytes.
However, hashlib.hexdigest returns str in both python2 and python3.