### PR TITLE
Add an option to control how to "revert back" when resuming a download; Fix argparse

### DIFF
--- a/bypy/bypy.py
+++ b/bypy/bypy.py
@@ -2945,13 +2945,13 @@ def getparser():
 
 	# program tunning, configration (those will be passed to class ByPy)
 	parser.add_argument("-r", "--retry",
-		dest="retry", default=5,
+		dest="retry", default=5, type=int,
 		help="number of retry attempts on network error [default: %(default)i times]")
 	parser.add_argument("-q", "--quit-when-fail",
-		dest="quit", default=False,
+		dest="quit", default=False, type=str2bool,
 		help="quit when maximum number of retry failed [default: %(default)s]")
 	parser.add_argument("-t", "--timeout",
-		dest="timeout", default=60,
+		dest="timeout", default=60.0, type=float,
 		help="network timeout in seconds [default: %(default)s]")
 	parser.add_argument("-s", "--slice",
 		dest="slice", default=const.DefaultSliceSize,
@@ -2960,13 +2960,13 @@ def getparser():
 		dest="chunk", default=const.DefaultDlChunkSize,
 		help="size of file download chunk (can use '1024', '2k', '3MB', etc) [default: {} MB]".format(const.DefaultDlChunkSize // const.OneM))
 	parser.add_argument("-e", "--verify",
-		dest="verify", action="store_true", default=False,
+		dest="verify", action="store_true",
 		help="verify upload / download [default : %(default)s]")
 	parser.add_argument("-f", "--force-hash",
 		dest="forcehash", action="store_true",
 		help="force file MD5 / CRC32 calculation instead of using cached value")
 	parser.add_argument("--resume-download",
-		dest="resumedl", default=True,
+		dest="resumedl", default=True, type=str2bool,
 		help="resume instead of restarting when downloading if local file already exists [default: %(default)s]")
 	parser.add_argument("--include-regex",
 		dest="incregex", default='',
@@ -3008,7 +3008,7 @@ def getparser():
 	# action
 	parser.add_argument(const.CleanOptionShort, const.CleanOptionLong,
 		dest="clean", action="count", default=0,
-		help="1: clean settings (remove the token file) 2: clean settings and hash cache [default: %(default)s]")
+		help="clean settings (remove the token file), -cc: clean settings and hash cache")
 
 	# the MAIN parameter - what command to perform
 	parser.add_argument("command", nargs='*', help = "operations (quota, list, etc)")
@@ -3091,9 +3091,7 @@ def main(argv=None): # IGNORE:C0111
 			parser.print_help()
 			return const.EArgument
 		elif args.command[0] in ByPy.__dict__: # dir(ByPy), dir(by)
-			timeout = None
-			if args.timeout:
-				timeout = float(args.timeout)
+			timeout = args.timeout or None
 
 			cached.usecache = not args.forcehash
 
@@ -3102,7 +3100,7 @@ def main(argv=None): # IGNORE:C0111
 			# I didn't use PanAPI here as I have never tried out those functions inside
 			by = ByPy(slice_size = slice_size, dl_chunk_size = chunk_size,
 					verify = args.verify,
-					retry = int(args.retry), timeout = timeout,
+					retry = args.retry, timeout = timeout,
 					quit_when_fail = args.quit,
 					resumedownload = args.resumedl,
 					incregex = args.incregex,


### PR DESCRIPTION
1.  增加一个选项：`--resume-download-revert-back RCOUNT` （这名字是有点长……）  
    目前程序的行为是断点续传时至少要重新下载最后一个区块  
    如果是下载 30M 的文件，默认 `chunk`=20M，那断点续传功能就等于直接失效……  
    现调整为：允许传入一个整数，控制回退区块的数目，默认值 `1` 与程序原来的行为一致，设为 `0` 表示只重下载最后一个不完整的区块（如有），为负则表示完全不回退而直接在文件末尾追加  
    如果是比较有信心在文件写入时不出现什么异常，这个选项还是可以用一用  
2.  顺带修改了一个参数处理的问题  
    `--quit-when-fail` 和 `--resume-download` 期望的是个布尔值，但传入的是字符串，除非参数用空字符串（`''` 或者写成 `--resume-download=`，感觉写起来都并不舒服），结果应该就都相当于 `True` 了。为保持命令格式不变（虽然这俩选项一般也不怎么用），现增加了个转换函数（或者就都换成 `store_true` 那样吧，不过就是不接受参数值了）（参考：<http://stackoverflow.com/questions/15008758/parsing-boolean-values-with-argparse>）  
    另外，也把一些简单的格式检查和转换交给 `argparse` 了
