### PR TITLE
Make `python setup.py test` pass when tk is not installed

### DIFF
--- a/bypy/monkey.py
+++ b/bypy/monkey.py
@@ -3,13 +3,24 @@
 # PYTHON_ARGCOMPLETE_OK
 
 from functools import partial
+import sys
 
 from . import printer_console
-from . import printer_gui
 from . import bypy
 from . import printer
 from . import cached
 from . import util
+
+try:
+	vi = sys.version_info
+	if vi[0] == 2:
+		import Tkinter
+	elif vi[0] == 3:
+		import tkinter
+except ImportError:
+	printer_gui = None
+else:
+	from . import printer_gui
 
 def setconsole():
 	bypy.pr = cached.pr = util.pr = printer_console.pr


### PR DESCRIPTION
On Arch Linux tk is not installed by default, so problems may occur when running tests:
```
$ python setup.py test
running test
running egg_info
creating bypy.egg-info
writing bypy.egg-info/PKG-INFO
writing dependency_links to bypy.egg-info/dependency_links.txt
writing entry points to bypy.egg-info/entry_points.txt
writing requirements to bypy.egg-info/requires.txt
writing top-level names to bypy.egg-info/top_level.txt
writing manifest file 'bypy.egg-info/SOURCES.txt'
reading manifest file 'bypy.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'bypy.egg-info/SOURCES.txt'
running build_ext
test (unittest.loader._FailedTest) ... ERROR
__main__ (unittest.loader._FailedTest) ... ERROR

======================================================================
ERROR: test (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: test
Traceback (most recent call last):
  File "/usr/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/yen/Projects/tmp/bypy/bypy/test/test.py", line 24, in <module>
    from .. import monkey
  File "/home/yen/Projects/tmp/bypy/bypy/monkey.py", line 8, in <module>
    from . import printer_gui
  File "/home/yen/Projects/tmp/bypy/bypy/printer_gui.py", line 12, in <module>
    from .tkutil import (
  File "/home/yen/Projects/tmp/bypy/bypy/tkutil.py", line 17, in <module>
    from tkinter import scrolledtext as scrt
  File "/usr/lib/python3.6/tkinter/__init__.py", line 36, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
ImportError: libtk8.6.so: cannot open shared object file: No such file or directory


======================================================================
ERROR: __main__ (unittest.loader._FailedTest)
----------------------------------------------------------------------
ImportError: Failed to import test module: __main__
Traceback (most recent call last):
  File "/usr/lib/python3.6/unittest/loader.py", line 153, in loadTestsFromName
    module = __import__(module_name)
  File "/home/yen/Projects/tmp/bypy/bypy/test/__main__.py", line 10, in <module>
    from .test import main
  File "/home/yen/Projects/tmp/bypy/bypy/test/test.py", line 24, in <module>
    from .. import monkey
  File "/home/yen/Projects/tmp/bypy/bypy/monkey.py", line 8, in <module>
    from . import printer_gui
  File "/home/yen/Projects/tmp/bypy/bypy/printer_gui.py", line 12, in <module>
    from .tkutil import (
  File "/home/yen/Projects/tmp/bypy/bypy/tkutil.py", line 17, in <module>
    from tkinter import scrolledtext as scrt
  File "/usr/lib/python3.6/tkinter/__init__.py", line 36, in <module>
    import _tkinter # If this fails your Python may not be configured for Tk
ImportError: libtk8.6.so: cannot open shared object file: No such file or directory


----------------------------------------------------------------------
Ran 2 tests in 0.000s

FAILED (errors=2)
Test failed: <unittest.runner.TextTestResult run=2 errors=2 failures=0>
error: Test failed: <unittest.runner.TextTestResult run=2 errors=2 failures=0>
```
This patch fixes the problem.