### PR TITLE
mac 升级经常搞丢环境变量 LC_ALL

### DIFF
--- a/bypy/gvar.py
+++ b/bypy/gvar.py
@@ -12,7 +12,13 @@ import time
 from . import const
 
 ## global variables
-SystemLanguageCode, SystemEncoding = locale.getdefaultlocale()
+try:
+	SystemLanguageCode, SystemEncoding = locale.getdefaultlocale()
+except ValueError as e:
+	if e.args and e.args[0] and e.args[0] == "unknown locale: UTF-8": # macOS 常见
+		SystemLanguageCode, SystemEncoding = '', 'UTF-8'
+	else:
+		raise
 # the previous time stdout was flushed, maybe we just flush every time, or maybe this way performs better
 # http://stackoverflow.com/questions/230751/how-to-flush-output-of-python-print
 last_stdout_flush = time.time()


### PR DESCRIPTION
只为 `LC_CTYPE == "UTF-8"` 的用户优化一下

尚未在所有环境测试