### PR TITLE
修改ByPy的__proceed_remote_gather函数，修复重复上传已存在文件的问题

### DIFF
--- a/bypy/bypy.py
+++ b/bypy/bypy.py
@@ -2599,7 +2599,11 @@ restore a file from the recycle bin
 
 		for f in filejs:
 			self.__remote_dir_contents.get(remotepath[rootlen:]).add(
-				f['path'][dlen:], PathDictTree('F', size = f['size'], md5 = f['md5']))
+				f['path'][dlen:], PathDictTree('F', size = f['size'], md5 = f['block_list'][0]))
+                # 网盘和本地文件相同，但本地文件md5与网盘获取到的md5值却不一致
+                # 与之对应的是在block_list列表中的值
+                # 此处修改后可实现增量上传，compare函数运行结果才是正确的
+				# f['path'][dlen:], PathDictTree('F', size = f['size'], md5 = f['md5']))
 
 		return walkresult
 


### PR DESCRIPTION
    您好，我在使用bypy工具上传文件夹后，再次上传该文件，网盘会把已经存在的文件删除重复上传文件。我使用compare函数对比以后发现，即使文件刚上传，两个文件compare结果也是不同文件。通过对文件md5的分析发现，本地文件md5值与请求返回的文件md5值并不一致，而存在与block_list对应的列表里。