### PR TITLE
Remove trailing ")" from URL in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This is a Python client for Baidu Yun (a.k.a PCS - Personal Cloud Storage), an o
 Prerequisite
 ------------
 
-**Important: You need to set you system locale encoding to UTF-8 for this to work (You can refer here: <http://perlgeek.de/en/article/set-up-a-clean-utf8-environment)>**
+**Important: You need to set you system locale encoding to UTF-8 for this to work (You can refer here: <http://perlgeek.de/en/article/set-up-a-clean-utf8-environment>)**
 
 Installation
 ------------


### PR DESCRIPTION
Fixing the link not working in the English readme