### PR TITLE
增加忽略文件功能

### DIFF
--- a/bypy/bypy.py
+++ b/bypy/bypy.py
@@ -54,6 +54,7 @@ from functools import partial
 from argparse import ArgumentParser
 from argparse import RawDescriptionHelpFormatter
 from copy import deepcopy
+import re
 
 # unify Python 2 and 3
 if sys.version_info[0] == 2:
@@ -1159,7 +1160,7 @@ Possible fixes:
 		for walk in os.walk(dir, followlinks=self._followlink):
 			ignore = False
 			for i in self.ignore_list:
-				if walk[0].startswith(os.path.normpath(i)):
+				if (walk[0].startswith(os.path.abspath(os.path.normpath(i)))) or not (re.match(i, walk[0]) is None):
 					ignore = True
 					self.pv(f'ignore {walk[0]}')
 					print(f'ignore {walk[0]}')

--- a/bypy/bypy.py
+++ b/bypy/bypy.py
@@ -1160,10 +1160,10 @@ Possible fixes:
 		for walk in os.walk(dir, followlinks=self._followlink):
 			ignore = False
 			for i in self.ignore_list:
-				if (walk[0].startswith(os.path.abspath(os.path.normpath(i)))) or not (re.match(i, walk[0]) is None):
+				if (walk[0].startswith(os.path.abspath(os.path.normpath(i)))) or (not (re.match(i, walk[0]) is None)):
 					ignore = True
 					self.pv(f'ignore {walk[0]}')
-					print(f'ignore {walk[0]}')
+					# print(f'ignore {walk[0]}')
 					break
 			if ignore:
 				continue


### PR DESCRIPTION
给 `syncup` `_compare` `compare` 增加了 `ignore_list` 参数
因为是直接 `not p in ignore_list` 建议判断前对用户输入的路径进行格式化

一个例子:
``` python
from bypy import ByPy
import os
bp=ByPy()
with open('ignore.txt') as f:
    ignore_list = f.read().split('\n')
ignore_list = [os.path.join(os.getcwd(), i) for i in ignore_list] # 转为绝对路径
print(ignore_list)
bp.syncup('/home/tim/', '/', ignore_list = ignore_list)
```