### PR TITLE
Fix: Make progress file path respect --config-dir parameter

### DIFF
--- a/bypy/bypy.py
+++ b/bypy/bypy.py
@@ -336,6 +336,7 @@ class ByPy(object):
 		self._configdir = configdir.rstrip("/\\ ")
 		makedir(self._configdir)
 		# os.path.join() may not handle unicode well on Python 2.7
+		self._progresspath = configdir + os.sep + const.ProgressFileName
 		self._tokenpath = configdir + os.sep + const.TokenFileName
 		self._settingpath = configdir + os.sep + const.SettingFileName
 		self._setting = {}
@@ -1562,7 +1563,7 @@ get information of the given path (dir / file) at Baidu Yun.
 		progress = {}
 
 		try:
-			progress = jsonload(const.ProgressPath)
+			progress = jsonload(self._progresspath)
 		except Exception as ex:
 			perr("Error loading the progress for: '{}'.\n{}.".format(fullpath, formatex(ex)))
 
@@ -1570,18 +1571,18 @@ get information of the given path (dir / file) at Baidu Yun.
 		progress[fullpath] = (self._slice_size, self._slice_md5s)
 
 		try:
-			jsondump(progress, const.ProgressPath, mpsemaphore)
+			jsondump(progress, self._progresspath, mpsemaphore)
 		except Exception as ex:
 			perr("Error updating the progress for: '{}'.\n{}.".format(fullpath, formatex(ex)))
 
 	def _delete_progress_entry(self, fullpath):
 		try:
-			progress = jsonload(const.ProgressPath)
+			progress = jsonload(self._progresspath)
 			# http://stackoverflow.com/questions/11277432/how-to-remove-a-key-from-a-python-dictionary
 			#del progress[fullpath]
 			self.pd("Removing slice upload progress for {}".format(fullpath))
 			progress.pop(fullpath, None)
-			jsondump(progress, const.ProgressPath, mpsemaphore)
+			jsondump(progress, self._progresspath, mpsemaphore)
 		except Exception as ex:
 			perr("Error deleting the progress for: '{}'.\n{}.".format(fullpath, formatex(ex)))
 
@@ -1607,14 +1608,14 @@ get information of the given path (dir / file) at Baidu Yun.
 		progress = {}
 		initial_offset = 0
 		# create an empty progress file first
-		if not os.path.exists(const.ProgressPath):
+		if not os.path.exists(self._progresspath):
 			try:
-				jsondump(progress, const.ProgressPath, mpsemaphore)
+				jsondump(progress, self._progresspath, mpsemaphore)
 			except Exception as ex:
 				perr("Error savingprogress, no resumption.\n{}".format(formatex(ex)))
 
 		try:
-			progress = jsonload(const.ProgressPath)
+			progress = jsonload(self._progresspath)
 		except Exception as ex:
 			perr("Error loading progress, no resumption.\n{}".format(formatex(ex)))
 


### PR DESCRIPTION
## 问题
进度文件路径被硬编码为使用 `const.ProgressPath`，不会放在通过 `--config-dir` 参数指定的配置目录。相比之下，其他配置文件（token, settings等）都正确使用了指定目录。

## 修改内容
- 在 `__init__` 方法中添加了 `self._progresspath` 的初始化
- 更新所有进度文件操作，使用 `self._progresspath` 替代 `const.ProgressPath`

## 受影响的方法
- `_update_progress_entry()`
- `_delete_progress_entry()`
- `_upload_file_slices()`

之前并发提交时遇到大文件会因为进度文件冲突报错，修改后再通过设置各自的config-dir就不会报错了。